### PR TITLE
ignore swift packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ fastlane/report.xml
 fastlane/Preview.html
 fastlane/screenshots
 fastlane/test_output
+
+# Swift Package Manager
+Packages/


### PR DESCRIPTION
`Packages/` is fetched by Swift package manager and should be ignored in the repo itself.