### PR TITLE
ignore swift package manager generated xcode project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,5 +67,8 @@ fastlane/test_output
 # Swift Package Manager
 Packages/
 
+# Ignore xcode generated project
+DiscreteData.xcodeproj
+
 # Ignore .DS_Store
 .DS_Store


### PR DESCRIPTION
Won't really need the xcode project.